### PR TITLE
Updating map to reflect new routes from TTNv3 fix.

### DIFF
--- a/flask_app/templates/map.html
+++ b/flask_app/templates/map.html
@@ -159,7 +159,7 @@
       legend_devices.addTo(map);
 
       function add_new_markers(past_seconds) {
-        var url = '/dsf673bh_past/' + past_seconds;
+        var url = '/past/' + past_seconds;
         $.getJSON(url,
           function (data, responseText, jqXHR) {
             if (jqXHR.status !== 204) {


### PR DESCRIPTION
The flask app route for fetching markers was updated in the previous TTNv3 fix but map.html did not reflect these updated route.
I confirmed this as working with my TTNv3 setup now. Markers are correctly shown on the map.